### PR TITLE
fix duplicate check with project paths

### DIFF
--- a/Seed/ViewModels/ProjectsViewModel.cs
+++ b/Seed/ViewModels/ProjectsViewModel.cs
@@ -151,7 +151,8 @@ public class ProjectsViewModel : ViewModelBase
         });
         if (file is null) return;
 
-        var duplicate = _projectManager.Projects.Any(x => file.Path.ToString().Contains(x.Path));
+        var filePath = file.Path.LocalPath[..^(file.Name.Length+1)];
+        var duplicate = _projectManager.Projects.Any(x => filePath.Equals(x.Path));
         if (duplicate)
         {
             var box = MessageBoxManager.GetMessageBoxStandard(


### PR DESCRIPTION
The current check is refusing to add a project that differs only in additional characters.
/some/directory/test
/some/directory/test2
The test2 is detected as a duplicate.